### PR TITLE
feat: parametrized count queries, add -c option for cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm i create-nexus-type --save-dev
   -mq      add this option to create Queries and Mutations for models
   -m       add this option to create Mutations
   -q       add this option to create Queries
+  -c       add this option to create Queries Count
   -f       add this option to add {filtering: true} option to Queries
   -o       add this option to add {ordering: true} option to Queries
   --js     create javascript version
@@ -55,7 +56,7 @@ model Post {
 run
 
 ```
-npx cnt --mq -f -o
+npx cnt --mq -c -f -o
 ```
 
 OutPut
@@ -80,6 +81,17 @@ schema.extendType({
   definition(t) {
     t.crud.user()
     t.crud.users({ filtering: true, ordering: true })
+
+    t.field('usersCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'UserWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.db.user.count({ where })
+        return { count }
+      },
+    })
   },
 })
 
@@ -115,6 +127,17 @@ schema.extendType({
   definition(t) {
     t.crud.post()
     t.crud.posts({ filtering: true, ordering: true })
+
+    t.field('postsCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'PostWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.db.post.count({ where })
+        return { count }
+      },
+    })
   },
 })
 
@@ -138,7 +161,7 @@ schema.extendType({
 run
 
 ```
-npx cnt -s --mq -f -o
+npx cnt -s --mq -c -f -o
 ```
 
 OutPut
@@ -161,6 +184,17 @@ export const userQuery = extendType({
   definition(t) {
     t.crud.user();
     t.crud.users({ filtering: true, ordering: true });
+
+    t.field('usersCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'UserWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.prisma.user.count({ where })
+        return { count }
+      },
+    });
   }
 });
 

--- a/examples/javascript/package.json
+++ b/examples/javascript/package.json
@@ -6,10 +6,10 @@
   "author": "Ahmed Elywa",
   "license": "MIT",
   "scripts": {
-    "cnt-js": "cnt -s --mq -f -o --js",
-    "cnt-mjs": "cnt -s --mq -f -o --mjs"
+    "cnt-js": "cnt -s --mq -f -o --js -c",
+    "cnt-mjs": "cnt -s --mq -f -o --mjs -c"
   },
   "devDependencies": {
-    "create-nexus-type": "^1.2.0"
+    "create-nexus-type": "file:../../"
   }
 }

--- a/examples/javascript/src/types/Post.js
+++ b/examples/javascript/src/types/Post.js
@@ -1,4 +1,4 @@
-import { objectType, extendType } from '@nexus/schema'
+const { objectType, extendType } = require('@nexus/schema')
 
 export const Post = objectType({
   name: 'Post',
@@ -8,15 +8,26 @@ export const Post = objectType({
   },
 })
 
-export const postQuery = extendType({
+const postQuery = extendType({
   type: 'Query',
   definition(t) {
     t.crud.post()
     t.crud.posts({ filtering: true, ordering: true })
+
+    t.field('postsCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'PostWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.prisma.post.count({ where })
+        return { count }
+      },
+    })
   },
 })
 
-export const postMutation = extendType({
+const postMutation = extendType({
   type: 'Mutation',
   definition(t) {
     t.crud.createOnePost()
@@ -28,3 +39,8 @@ export const postMutation = extendType({
     t.crud.deleteManyPost()
   },
 })
+module.exports = {
+  Post,
+  postQuery,
+  postMutation,
+}

--- a/examples/javascript/src/types/User.js
+++ b/examples/javascript/src/types/User.js
@@ -1,4 +1,4 @@
-import { objectType, extendType } from '@nexus/schema'
+const { objectType, extendType } = require('@nexus/schema')
 
 export const User = objectType({
   name: 'User',
@@ -11,15 +11,26 @@ export const User = objectType({
   },
 })
 
-export const userQuery = extendType({
+const userQuery = extendType({
   type: 'Query',
   definition(t) {
     t.crud.user()
     t.crud.users({ filtering: true, ordering: true })
+
+    t.field('usersCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'UserWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.prisma.user.count({ where })
+        return { count }
+      },
+    })
   },
 })
 
-export const userMutation = extendType({
+const userMutation = extendType({
   type: 'Mutation',
   definition(t) {
     t.crud.createOneUser()
@@ -31,3 +42,8 @@ export const userMutation = extendType({
     t.crud.deleteManyUser()
   },
 })
+module.exports = {
+  User,
+  userQuery,
+  userMutation,
+}

--- a/examples/javascript/src/types/index.js
+++ b/examples/javascript/src/types/index.js
@@ -1,2 +1,4 @@
-export * from './User'
-export * from './Post'
+module.exports = {
+  ...require('./User'),
+  ...require('./Post'),
+}

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -6,10 +6,10 @@
   "author": "Ahmed Elywa",
   "license": "MIT",
   "scripts": {
-    "cnt": "cnt --mq -f -o",
+    "cnt": "cnt --mq -f -o -c",
     "types": "create-types"
   },
   "devDependencies": {
-    "create-nexus-type": "^1.2.0"
+    "create-nexus-type": "file:../../"
   }
 }

--- a/examples/typescript/src/types/Post.ts
+++ b/examples/typescript/src/types/Post.ts
@@ -13,6 +13,17 @@ schema.extendType({
   definition(t) {
     t.crud.post()
     t.crud.posts({ filtering: true, ordering: true })
+
+    t.field('postsCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'PostWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.db.post.count({ where })
+        return { count }
+      },
+    })
   },
 })
 

--- a/examples/typescript/src/types/User.ts
+++ b/examples/typescript/src/types/User.ts
@@ -16,6 +16,17 @@ schema.extendType({
   definition(t) {
     t.crud.user()
     t.crud.users({ filtering: true, ordering: true })
+
+    t.field('usersCount', {
+      type: 'BatchPayload',
+      args: {
+        where: 'UserWhereInput',
+      },
+      async resolve(_root, { where }, ctx) {
+        const count = await ctx.db.user.count({ where })
+        return { count }
+      },
+    })
   },
 })
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ function getArgs() {
     '--mq': Boolean,
     '-m': Boolean,
     '-q': Boolean,
+    '-c': Boolean,
     '-f': Boolean,
     '-o': Boolean,
     '-s': Boolean,
@@ -50,6 +51,7 @@ function help() {
   -mq      add this option to create Queries and Mutations for models 
   -m       add this option to create Mutations
   -q       add this option to create Queries
+  -c       add this option to create Queries Count
   -f       add this option to add {filtering: true} option to Queries
   -o       add this option to add {ordering: true} option to Queries
   --js     create javascript version

--- a/src/nexus.js
+++ b/src/nexus.js
@@ -24,6 +24,22 @@ function buildForNexusVersion(schema, args) {
       plural: pluralize(newName),
       singular: newName,
     };
+
+    let queryCount=''
+    if(args['-c']) {
+      queryCount = `
+      t.field('${modelName.plural}Count', {
+        type: 'BatchPayload',
+        args: {
+          where: '${model.name}WhereInput',
+        },
+        async resolve(_root, { where }, ctx) {
+          const count = await ctx.db.${modelName.singular}.count({ where })
+          return { count }
+        },
+      })`;
+    }
+
     if (args['--mq'] || args['-q']) {
       fileContent += `
 
@@ -40,6 +56,7 @@ schema.extendType({
           ? '{ ordering: true }'
           : ''
       })
+${queryCount}
   },
 })`;
     }

--- a/src/schema.js
+++ b/src/schema.js
@@ -36,6 +36,22 @@ function buildForSchemaVersion(schema, args) {
       plural: pluralize(newName),
       singular: newName,
     };
+
+    let queryCount=''
+    if(args['-c']) {
+      queryCount = `
+      t.field('${modelName.plural}Count', {
+        type: 'BatchPayload',
+        args: {
+          where: '${model.name}WhereInput',
+        },
+        async resolve(_root, { where }, ctx) {
+          const count = await ctx.db.${modelName.singular}.count({ where })
+          return { count }
+        },
+      })`;
+    }
+
     if (args['--mq'] || args['-q']) {
       fileContent += `
 
@@ -52,6 +68,7 @@ ${args['--js'] ? '' : 'export '}const ${modelName.singular}Query = extendType({
           ? '{ ordering: true }'
           : ''
       })
+${queryCount}
   },
 })`;
       moduleExports += `


### PR DESCRIPTION
prisma-client added parameterized count API from 2.0.0-beta.2, and now added `ModelnameCount` related `Query` code generation cli option `-c`.

```ts
schema.extendType({
  type: 'Query',
  definition(t) {
    t.crud.user()
    t.crud.users({ filtering: true, ordering: true })

// count
    t.field('usersCount', {
      type: 'BatchPayload',
      args: {
        where: 'UserWhereInput',
      },
      async resolve(_root, { where }, ctx) {
        const count = await ctx.db.user.count({ where })
        return { count }
      },
    })
  },
})
```